### PR TITLE
Fix Gemname in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ depends on [mini_magick](https://github.com/minimagick/minimagick) for resizing 
 ## Installation
 
 ```ruby
-gem 'middleman_images'
+gem 'middleman-images'
 ```
 
 Resizing images requires ImageMagick to be available. Check


### PR DESCRIPTION
The Gem's name was misspelled in the repo using an underscore instead of a hyphen, which yielded installation errors. This fixes it.