### PR TITLE
Getting this extension to work

### DIFF
--- a/lib/middleman-images/extension.rb
+++ b/lib/middleman-images/extension.rb
@@ -40,7 +40,7 @@ module Middleman
         process_options[:image_optim] = self.options[:image_optim]
         process_options[:optimize] = self.options[:optimize] unless process_options.key?(:optimize)
         if process_options[:resize] || process_options[:optimize]
-          source = app.sitemap.find_resource_by_path(absolute_image_path(url))
+          source = app.sitemap.find_resource_by_destination_path(absolute_image_path(url))
           url = process(source, process_options) if source
         end
         url


### PR DESCRIPTION
Hey!

So last night I tried using this extension, but nothing happened every time I ran a build. I ended up digging into the code and realized that at the moment where the code is looking up the image in the sitemap...

```
app.sitemap.find_resource_by_path(absolute_image_path(url))
```

...was returning `nil` instead of the file resource it was supposed to. I changed `find_resource_by_path()` to `find_resource_by_destination_path()`, and now it works like a charm!

Not sure why it seems to be working for everyone else but not for me, but I figured I'd include my fix for anyone else who needs it.

Currently running Middleman 4.2.1
