### PR TITLE
Lock image_optim_pack version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,7 @@ group :test do
   gem 'capybara'
   gem 'aruba'
   gem 'rspec'
-  gem 'image_optim_pack'
+
+  # Version is locked to make sure asset_hash tests are not broken by updated optimizations.
+  gem 'image_optim_pack', '=0.6.0'
 end


### PR DESCRIPTION
`asset_hash` tests generated different hash for optimizied files on newer versions of image_optim_pack.
We don't need to test our Gem with newer versions of image_optim_pack necessarily, so I think this is okay to lock