### PR TITLE
Use render to trigger image helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- We changed the way images get registered while running the Middleman server.
+  This should bring way better performance and make this Gem usable in server mode.t
 
 ## [0.1.0] - 2020-02-05
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,37 +43,34 @@ For more information check [`image_optim_pack`](https://github.com/toy/image_opt
 To activate the extension just put this into your `config.rb`:
 
 ```ruby
-configure :build do
-  activate :images
-end
+activate :images
 ```
 
-Although it is possible to activate the extension in development mode, we do
-not recommend this. Since this will radically drain the performance.
+With Middleman images activated, starting the Middleman server will take some time.
+During that time images that need procssing will get registered.
+The actual processing of the images takes place while navigating the page.
 
 Configure the extension by passing a block to `:activate`:
 
 ```ruby
-configure :build do
-  activate :images do |images|
-    # Do not include original images in the build (default: false)
-    images.ignore_original = true
+activate :images do |images|
+  # Do not include original images in the build (default: false)
+  images.ignore_original = true
 
-    # Specify another cache directory depending on your root directory (default: 'cache')
-    images.cache_dir = 'funky_cache/subdir_of_funky_cache'
+  # Specify another cache directory depending on your root directory (default: 'cache')
+  images.cache_dir = 'funky_cache/subdir_of_funky_cache'
 
-    # Optimize images (default: false)
-    images.optimize = true
+  # Optimize images (default: false)
+  images.optimize = true
 
-    # Provide additional options for image_optim
-    # See https://github.com/toy/image_optim for all available options
-    images.image_optim = {
-      nice: 20,
-      optipng: {
-        level: 5,
-      },
-    }
-  end
+  # Provide additional options for image_optim
+  # See https://github.com/toy/image_optim for all available options
+  images.image_optim = {
+    nice: 20,
+    optipng: {
+      level: 5,
+    },
+  }
 end
 ```
 

--- a/features/building.feature
+++ b/features/building.feature
@@ -31,8 +31,10 @@ Feature: Building images
       """
     And the Server is running
     And I go to "/first.html"
+    And I go to "/images/fox-opt.jpg"
     And a modification time for a file named "cache/images/fox-opt.jpg"
-    When I go to "/second.html"
+    And I go to "/second.html"
+    When I go to "/images/fox-opt.jpg"
     Then the file "cache/images/fox-opt.jpg" should exist
     Then the file "cache/images/fox-opt.jpg" should not have been updated
 

--- a/lib/middleman-images/image.rb
+++ b/lib/middleman-images/image.rb
@@ -24,6 +24,8 @@ module Middleman
         optimize(cache, options[:image_optim]) if options[:optimize]
       end
 
+      # We want to process images as late as possible. Before Middleman works with our source file, it will check
+      # whether it is binary? or static_file?. That's when we need to ensure the processed source files exist.
       def binary?
         process
         super

--- a/lib/middleman-images/image.rb
+++ b/lib/middleman-images/image.rb
@@ -1,6 +1,6 @@
 module Middleman
   module Images
-    class Image
+    class Image < Middleman::Sitemap::Resource
       attr_reader :destination, :source
 
       def initialize(app, source, destination, options = {})
@@ -10,19 +10,28 @@ module Middleman
         @options = options
         @cache = File.join(app.root, 'cache', destination).to_s
         FileUtils.mkdir_p File.dirname(cache)
+
+        super(app.sitemap, destination, cache)
       end
 
       def process
         return if File.exist?(cache) && File.mtime(source) < File.mtime(cache)
 
         app.logger.info "== Images: Processing #{destination}"
+
         FileUtils.copy(source, cache)
         resize(cache, options[:resize]) unless options[:resize].nil?
         optimize(cache, options[:image_optim]) if options[:optimize]
       end
 
-      def resource
-        @resource ||= ::Middleman::Sitemap::Resource.new(app.sitemap, destination, cache)
+      def binary?
+        process
+        super
+      end
+
+      def static_file?
+        process
+        super
       end
 
       private

--- a/lib/middleman-images/manipulator.rb
+++ b/lib/middleman-images/manipulator.rb
@@ -28,11 +28,12 @@ module Middleman
           app.logger.debug "== Images: Inspecting #{resource.destination_path} for images to process."
 
           @inspected_at[resource.source_file] = File.mtime(resource.source_file)
-          resource.render
-
-        rescue => e
-          app.logger.debug e
-          app.logger.debug "== Images: There was an error inspecting #{resource.destination_path}. Images for this resource will not be processed."
+          begin
+            resource.render
+          rescue => e
+            app.logger.debug e
+            app.logger.debug "== Images: There was an error inspecting #{resource.destination_path}. Images for this resource will not be processed."
+          end
         end
 
         app.logger.info "== Images: All images have been registered."

--- a/lib/middleman-images/manipulator.rb
+++ b/lib/middleman-images/manipulator.rb
@@ -46,6 +46,8 @@ module Middleman
       attr_accessor :app, :images, :ignore_original, :required_originals
 
       def inspect?(resource)
+        return false unless resource.template?
+
         inspected_at = @inspected_at[resource.source_file]
         return true if inspected_at.nil?
 

--- a/lib/middleman-images/manipulator.rb
+++ b/lib/middleman-images/manipulator.rb
@@ -29,6 +29,8 @@ module Middleman
 
           @inspected_at[resource.source_file] = File.mtime(resource.source_file)
           begin
+            # We inspect templates by triggering the render method on them. This way our
+            # image_tag and image_path helpers will get called and register the images.
             resource.render({}, {})
           rescue => e
             app.logger.debug e

--- a/lib/middleman-images/manipulator.rb
+++ b/lib/middleman-images/manipulator.rb
@@ -29,7 +29,7 @@ module Middleman
 
           @inspected_at[resource.source_file] = File.mtime(resource.source_file)
           begin
-            resource.render
+            resource.render({}, {})
           rescue => e
             app.logger.debug e
             app.logger.debug "== Images: There was an error inspecting #{resource.destination_path}. Images for this resource will not be processed."

--- a/lib/middleman-images/manipulator.rb
+++ b/lib/middleman-images/manipulator.rb
@@ -19,6 +19,11 @@ module Middleman
       end
 
       def manipulate_resource_list(resources)
+        resources.each do |resource|
+          resource.render
+        rescue => e
+          app.logger.warn "== Images: There was an error finding images to process in the resource #{resource.path}#{resource.ext}. Images in this resource will not be processed."
+        end
         ignore_orginal_resources(resources) if ignore_original
         resources + processed_images
       end


### PR DESCRIPTION
Image helpers get triggered when rendering template files. We used a mock lookup when building the app to trigger that rendering. This is not working with Middleman 5 anymore, just like that.

Another problem is, that when running Middleman in server mode, we had to re-register our resource manipulator everytime a new image was found, which led to unusable performance on bigger apps.

We now trigger the rendering of templates manually when our manipulator gets called (once for each template, and when it is updated). That way it takes some time initially to "inspect" all templates and register our images to process, but after that, the page runs smoothly.

Building apps is not hit by performance issues, since we essentially do the same here as before. Just not by visiting every page, but by rendering every template ressource.