### PR TITLE
Refactor image class to be more in line with middleman resources

### DIFF
--- a/lib/middleman-images/extension.rb
+++ b/lib/middleman-images/extension.rb
@@ -34,7 +34,7 @@ module Middleman
       def process(source, process_options)
         destination_path(source, process_options).tap do |dest_url|
           unless app.sitemap.find_resource_by_path(dest_url)
-            image = Image.new(app, source.source_file, dest_url, process_options.merge(cache_dir: options[:cache_dir]))
+            image = Image.new(app.sitemap, dest_url, source.source_file, process_options.merge(cache_dir: options[:cache_dir]))
             manipulator.add image
           end
         end

--- a/lib/middleman-images/image.rb
+++ b/lib/middleman-images/image.rb
@@ -6,7 +6,7 @@ module Middleman
         ".gif" =>  "WARNING: We did not resize %{file}. Resizing GIF files will remove the animation. If your GIF file is not animated, use JPG or PNG instead.",
       }.freeze
 
-      attr_reader :app
+      attr_reader :app, :original_source_file
 
       def initialize(store, path, source, options = {})
         @original_source_file = source
@@ -20,11 +20,11 @@ module Middleman
       end
 
       def process
-        return if File.exist?(source_file) && File.mtime(@original_source_file) < File.mtime(source_file)
+        return if File.exist?(source_file) && File.mtime(original_source_file) < File.mtime(source_file)
 
         app.logger.info "== Images: Processing #{@path}"
 
-        FileUtils.copy(@original_source_file, source_file)
+        FileUtils.copy(original_source_file, source_file)
         resize(source_file, @processing_options[:resize]) unless @processing_options[:resize].nil?
         optimize(source_file, @processing_options[:image_optim]) if @processing_options[:optimize]
       end

--- a/lib/middleman-images/image.rb
+++ b/lib/middleman-images/image.rb
@@ -11,22 +11,22 @@ module Middleman
       def initialize(store, path, source, options = {})
         @original_source_file = source
 
-        cache = File.join(store.app.root, options.delete(:cache_dir), path).to_s
-        FileUtils.mkdir_p File.dirname(cache)
+        processed_source_file = File.join(store.app.root, options.delete(:cache_dir), path)
+        FileUtils.mkdir_p File.dirname(processed_source_file)
 
         @processing_options = options
 
-        super(store, path, cache)
+        super(store, path, processed_source_file)
       end
 
       def process
-        return if File.exist?(source_file) && File.mtime(original_source_file) < File.mtime(source_file)
+        return if File.exist?(processed_source_file) && File.mtime(original_source_file) < File.mtime(processed_source_file)
 
         app.logger.info "== Images: Processing #{@path}"
 
-        FileUtils.copy(original_source_file, source_file)
-        resize(source_file, @processing_options[:resize]) unless @processing_options[:resize].nil?
-        optimize(source_file, @processing_options[:image_optim]) if @processing_options[:optimize]
+        FileUtils.copy(original_source_file, processed_source_file)
+        resize(processed_source_file, @processing_options[:resize]) unless @processing_options[:resize].nil?
+        optimize(processed_source_file, @processing_options[:image_optim]) if @processing_options[:optimize]
       end
 
       # We want to process images as late as possible. Before Middleman works with our source file, it will check
@@ -39,6 +39,11 @@ module Middleman
       def static_file?
         process
         super
+      end
+
+      # The processed source file is the new source file for middleman.
+      def processed_source_file
+        source_file
       end
 
       private

--- a/lib/middleman-images/image.rb
+++ b/lib/middleman-images/image.rb
@@ -6,6 +6,8 @@ module Middleman
         ".gif" =>  "WARNING: We did not resize %{file}. Resizing GIF files will remove the animation. If your GIF file is not animated, use JPG or PNG instead.",
       }.freeze
 
+      attr_reader :app
+
       def initialize(store, path, source, options = {})
         @original_source_file = source
 

--- a/lib/middleman-images/manipulator.rb
+++ b/lib/middleman-images/manipulator.rb
@@ -58,7 +58,7 @@ module Middleman
       end
 
       def ignore_orginal_resources(resources)
-        originals = images.map(&:source)
+        originals = images.map(&:source_file)
         unused_originals = originals - required_originals
 
         resources.each do |resource|

--- a/lib/middleman-images/manipulator.rb
+++ b/lib/middleman-images/manipulator.rb
@@ -58,7 +58,7 @@ module Middleman
       end
 
       def ignore_orginal_resources(resources)
-        originals = images.map(&:source_file)
+        originals = images.map(&:original_source_file)
         unused_originals = originals - required_originals
 
         resources.each do |resource|


### PR DESCRIPTION
Refactoring of the `image` class, to be in line with `Middleman::Sitemap::Resource`. We don't want to override any of their methods so I tried to remove as much of the `attr_reader` as possible and use public methods on the middleman resources instead.