### PR TITLE
Fix: Inspect proxy resources

### DIFF
--- a/features/proxy_resources.feature
+++ b/features/proxy_resources.feature
@@ -1,0 +1,39 @@
+
+Feature: Proxy resources
+
+  Scenario: Resizing images for a proxy resource on build
+    Given a fixture app "image"
+    And a middleman configuration with:
+      """
+      activate :i18n, langs: [:en, :de], mount_at_root: false
+      """
+    And our extension is enabled
+    And a template named "localizable/index.html.erb" with:
+      """
+      <%= image_tag 'fox.jpg', resize: (I18n.locale == :en ? 400 : 500) %>
+      """
+    When a successfully built app at "image"
+    When I cd to "build/images"
+    Then a file named "fox-400.jpg" should exist
+    And a file named "fox-500.jpg" should exist
+
+  Scenario: Resizing images for a proxy resource on server
+    Given a fixture app "image"
+    And a middleman configuration with:
+      """
+      activate :i18n, langs: [:en, :de], mount_at_root: false
+      """
+    And our extension is enabled
+    And a template named "localizable/index.html.erb" with:
+      """
+      <%= image_tag 'fox.jpg', resize: (I18n.locale == :en ? 400 : 500) %>
+      """
+    And the Server is running
+    When I go to "/en/index.html"
+    Then I should see '<img src="/images/fox-400.jpg" alt="Fox" />'
+    When I go to "/images/fox-400.jpg"
+    Then the status code should be "200"
+    When I go to "/de/index.html"
+    Then I should see '<img src="/images/fox-500.jpg" alt="Fox" />'
+    When I go to "/images/fox-500.jpg"
+    Then the status code should be "200"

--- a/features/support/middleman_images_steps.rb
+++ b/features/support/middleman_images_steps.rb
@@ -1,11 +1,17 @@
 require 'mini_magick'
 
+Given /^a middleman configuration with:$/ do |config|
+  @middleman_config = config
+end
+
 Given /^our extension is enabled?$/ do
   step 'our extension is enabled with:', ''
 end
 
 Given /^our extension is enabled with:$/ do |config|
   config = """
+    #{@middleman_config}
+
     activate :images do |config|
       config.image_optim = {
         pngout: false,

--- a/lib/middleman-images/manipulator.rb
+++ b/lib/middleman-images/manipulator.rb
@@ -27,7 +27,6 @@ module Middleman
 
           app.logger.debug "== Images: Inspecting #{resource.destination_path} for images to process."
 
-          @inspected_at[resource.source_file] = File.mtime(resource.source_file)
           begin
             # We inspect templates by triggering the render method on them. This way our
             # image_tag and image_path helpers will get called and register the images.
@@ -51,10 +50,13 @@ module Middleman
       def inspect?(resource)
         return false unless resource.template?
 
-        inspected_at = @inspected_at[resource.source_file]
+        inspected_at = @inspected_at[resource.destination_path]
         return true if inspected_at.nil?
 
-        inspected_at < File.mtime(resource.source_file)
+        source_modification_time = File.mtime(resource.source_file)
+        inspected_at < source_modification_time.tap do |inspect|
+          @inspected_at[resource.destination_path] = source_modification_time if inspect
+        end
       end
 
       def ignore_orginal_resources(resources)


### PR DESCRIPTION
There was an error, we introduced in #48 I found, while using the current `master` on our website project. Proxy ressources did no get analyzed. They do now. 9d7960e shows the error.